### PR TITLE
Implicit destructor for Task's data when type is not trivially destructible

### DIFF
--- a/source/gts/include/gts/micro_scheduler/Task.h
+++ b/source/gts/include/gts/micro_scheduler/Task.h
@@ -184,6 +184,7 @@ public: // MUTATORS:
     template<typename T, typename... TArgs>
     GTS_INLINE T* emplaceData(TArgs&&... args)
     {
+        static_assert(std::is_trivially_destructible<T>::value);
         m_state |= TASK_HAS_DATA_SUFFIX;
         return new (_dataSuffix()) T(std::forward<TArgs>(args)...);
     }
@@ -194,6 +195,7 @@ public: // MUTATORS:
     template<typename T>
     GTS_INLINE T* setData(T const& data)
     {
+        static_assert(std::is_trivially_destructible<T>::value);
         m_state |= TASK_HAS_DATA_SUFFIX;
         return new (_dataSuffix()) T(data);
     }

--- a/source/gts/source/micro_scheduler/Schedule.cpp
+++ b/source/gts/source/micro_scheduler/Schedule.cpp
@@ -162,6 +162,7 @@ void Schedule::wait(Task* pWaitingTask, Task* pStartTask, Backoff& backoff)
 
                 // Execute!
                 pTask->m_state |= Task::TASK_IS_EXECUTING;
+                pTask->m_state &= ~Task::TASK_IS_QUEUED;
                 pNextTask = pTask->execute(pTask, TaskContext{ m_pMyScheduler, workerIdx });
 
                 GTS_ASSERT((!pNextTask || (pNextTask && !(pNextTask->m_state & Task::TASK_IS_CONTINUATION))) &&


### PR DESCRIPTION
As performance of Task's data destructors can be a problem, i tried to find a way to reduce the cost and use it only when types required it.

The main idea is to inline the task execution code in a wrapper together with the code for destruction, in this way we dont need to add any additional indirect function call.

Note this PR is mostly for discussion about the idea, as i feel i have not sufficient knowledge on how GTS works.

Note: Use lambdas for the task function only will work with c++20.

Sorry, if I'm missing some important detail and the idea is failing :P
