### PR TITLE
Debug code to assert Task's data destructor are called when type is non trivially destructible.

### DIFF
--- a/source/gts/source/micro_scheduler/MicroScheduler.cpp
+++ b/source/gts/source/micro_scheduler/MicroScheduler.cpp
@@ -234,6 +234,7 @@ void MicroScheduler::_freeTask(uint32_t workerIdx, Task* pTask)
 {
     GTS_ASSERT(pTask != nullptr);
 
+    GTS_ASSERT((pTask->m_state & Task::TASK_NEED_DATA_DESTRUCTOR) == 0);
     GTS_ANALYSIS_COUNT(workerIdx, gts::analysis::AnalysisType::NUM_FREES);
     GTS_ANALYSIS_TIME_SCOPED(workerIdx, gts::analysis::AnalysisType::NUM_FREES);
     GTS_INSTRUMENTER_SCOPED(analysis::Tag::INTERNAL, "FREE TASK", pTask, 0);


### PR DESCRIPTION
A different idea related the data destructors.

This code only works when GTS_ASSERT are enabled, in this way the performance in release in not affected.

The new asserts ensure Task::destructData will be called before any other data initialization or Task destruction.

Note: this PR is mostly for discussion about the idea, as i feel i have not sufficient knowledge on how GTS works.